### PR TITLE
Updated layout, added xkb 2.39 notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
+**Note: if you are using xkeyboard-config version 2.39 or newer, you already have the Windows Persian layout installed, and don't need this repo.**
+
 I have been looking for a way to change to the keyboard layout of the Persian language for the Ubuntu operating system for a few years, which might be identical to the one I used to have while I was a windows user. This is probably the problem of most of the people who want to use Ubuntu. However, they cannot switch to it since it is almost impossible to type correctly using its predefined Persian language keyboard.
 
-The instruction is the same. you should modify the `ir` and `evdev.xml` files. I hope it would be helpful for those who get used to the layout of windows and love to work with a real operating system.
+I hope it would be helpful for those who get used to the layout of Windows and love to work with a real operating system.
 
 Enjoy.
-
-**Note: If your Linux distribution has a version of xkb with [!473](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/merge_requests/473) merged, you already have a Windows Persian layout, and do not need this repo.**
 
 
 ## Automatic Installation
@@ -12,7 +12,7 @@ Enjoy.
 The automatic installer script requires `xmlstarlet` to be installed.
 Install it using your package manager before running the script.
 
-**Warning: The automatic installer does not detect any previous versions of this project. Make sure you don't already have an older version of the Windows Persian layout installed.**
+**Warning: The automatic installer does not detect any previous versions of this project. If you are updating from a previous version, make sure you don't already have an older version of the Windows Persian layout installed.**
 
 1. Clone the repository
 
@@ -43,7 +43,7 @@ cd windows-persian-keyboard-for-linux
 
 ```bash
 sudo cp /usr/share/X11/xkb/symbols/ir /usr/share/X11/xkb/symbols/ir.backup
-sudo cat ./ir | sudo tee -a /usr/share/X11/xkb/symbols/ir &>/dev/null
+cat ./ir_patch | sudo tee -a /usr/share/X11/xkb/symbols/ir >/dev/null
 ```
 
 3. Edit the xkb layouts registry with your text editor of choice (vim for example),
@@ -58,7 +58,7 @@ find the Persian layout and add this variant to the list of variants for Persian
 ```xml
         <variant>
           <configItem>
-            <name>pes_winkeys</name>
+            <name>winkeys</name>
             <description>Persian (Windows)</description>
           </configItem>
         </variant>

--- a/install
+++ b/install
@@ -5,7 +5,7 @@
 # https://github.com/sinadarvi/windows-persian-layout-for-linux
 
 # Script by cs127 <https://cs127.github.io>
-# 2023-03-11
+# 2023-03-20
 
 # Requirements:
 # * xmlstarlet
@@ -33,7 +33,7 @@ XKBREG="$XKBHOME/rules/evdev.xml"
 
 XML_IR="/xkbConfigRegistry/layoutList/layout[configItem/name='ir']"
 XML_VL="$XML_IR/variantList"
-XML_VL_WIN="$XML_VL/variant[configItem/name='pes_winkeys']"
+XML_VL_WIN="$XML_VL/variant[configItem/name='winkeys']"
 XML_VL_LAST="$XML_VL/variant[last()]"
 XML_VL_LCFG="$XML_VL_LAST/configItem"
 
@@ -59,7 +59,7 @@ process_registry() {
     ! xmlstarlet ed -P -L \
     -s "$XML_VL" -t elem -n "variant" \
     -s "$XML_VL_LAST" -t elem -n "configItem" \
-    -s "$XML_VL_LCFG" -t elem -n "name" -v "pes_winkeys" \
+    -s "$XML_VL_LCFG" -t elem -n "name" -v "winkeys" \
     -s "$XML_VL_LCFG" -t elem -n "description" -v "Persian (Windows)" \
     "$XKBREG" &&
     mv "$XKBREG.backup" "$XKBREG" && exitcode 12

--- a/ir_patch
+++ b/ir_patch
@@ -4,19 +4,20 @@
 // ========================
 
 partial alphanumeric_keys
-xkb_symbols "pes_winkeys" {
+xkb_symbols "winkeys" {
     name[Group1]= "Persian (Windows)";
 
-    key <AE01> { [ Farsi_1,	exclam		] };
-    key <AE02> { [ Farsi_2,	at		] };
-    key <AE03> { [ Farsi_3,	numbersign	] };
-    key <AE04> { [ Farsi_4,	dollar		] };
-    key <AE05> { [ Farsi_5,	percent		] };
-    key <AE06> { [ Farsi_6,	asciicircum	] };
-    key <AE07> { [ Farsi_7,	ampersand	] };
-    key <AE08> { [ Farsi_8,	asterisk	] };
-    key <AE09> { [ Farsi_9,	parenright	] };
-    key <AE10> { [ Farsi_0,	parenleft	] };
+    key <TLDE> { [ division,	multiply	] };
+    key <AE01> { [ 1,		exclam,		Farsi_1,	0x100200d	] };
+    key <AE02> { [ 2,		at,		Farsi_2,	0x100200c	] };
+    key <AE03> { [ 3,		numbersign,	Farsi_3,	0x100200e	] };
+    key <AE04> { [ 4,		dollar,		Farsi_4,	0x100200f	] };
+    key <AE05> { [ 5,		percent,	Farsi_5	] };
+    key <AE06> { [ 6,		asciicircum,	Farsi_6	] };
+    key <AE07> { [ 7,		ampersand,	Farsi_7	] };
+    key <AE08> { [ 8,		asterisk,	Farsi_8	] };
+    key <AE09> { [ 9,		parenright,	Farsi_9	] };
+    key <AE10> { [ 0,		parenleft,	Farsi_0	] };
     key <AE11> { [ minus,	underscore	] };
     key <AE12> { [ equal,	plus		] };
 
@@ -44,9 +45,9 @@ xkb_symbols "pes_winkeys" {
     key <AC09> { [ Arabic_meem,		guillemotright		] };
     key <AC10> { [ Arabic_keheh,	colon			] };
     key <AC11> { [ Arabic_gaf,		quotedbl		] };
-    key <TLDE> { [ division,		multiply		] };
-
     key <BKSL> { [ Arabic_peh,		bar			] };
+
+    key <LSGT> { [ Arabic_peh,		bar			] };
     key <AB01> { [ Arabic_zah,		Arabic_tehmarbuta	] };
     key <AB02> { [ Arabic_tah,		Arabic_yeh		] };
     key <AB03> { [ Arabic_zain,		Arabic_jeh		] };
@@ -58,6 +59,5 @@ xkb_symbols "pes_winkeys" {
     key <AB09> { [ period,		greater			] };
     key <AB10> { [ slash,		Arabic_question_mark	] };
 
-    include "nbsp(zwnj2nb3nnb4)"
     include "level3(ralt_switch)"
 };


### PR DESCRIPTION
* Changed layout ID from `ir(pes_winkeys)` to `ir(winkeys)` to match the latest commit in xkb config.
* Changed the number keys on row E to type ASCII Latin digits instead of Persian digits.
* Added Persian digits to the third level of the number keys on row E.
* Added Unicode characters ZWJ, ZWNJ, LRM, and RLM to the fourth level of the keys `AE01` - `AE04`.
* Added the letter Pe (U+067E) to the `LSGT` key, located to the left of `AB01` on some keyboards.
* Removed the `nbsp` inclusion.
* Added a notice about xkb config v2.39.