### PR TITLE
Update ir_patch

### DIFF
--- a/ir_patch
+++ b/ir_patch
@@ -59,5 +59,4 @@ xkb_symbols "pes_winkeys" {
     key <AB10> { [ slash,		Arabic_question_mark	] };
 
     include "nbsp(zwnj2nb3nnb4)"
-    include "level3(ralt_switch)"
 };


### PR DESCRIPTION
Hello, 
I've eliminated the line "include "level3(ralt_switch)"" from the "ir_patch" configuration. This adjustment was necessary because I typically switch between different keyboard layouts using the alt+shift combination. With the mentioned line in place, I encountered an issue where I couldn't seamlessly switch the language from Persian to, for instance, English using the right alt + shift shortcut.